### PR TITLE
Define Content-Type on apiHeaders for HTTP requests to GitHub

### DIFF
--- a/action.ps1
+++ b/action.ps1
@@ -34,7 +34,7 @@ $gistsApiUrl = "https://api.github.com/gists"
 $apiHeaders = @{
     Accept        = "application/vnd.github.v2+json"
     Authorization = "token $gist_token"
-    Content-Type  = "application/json"
+    "Content-Type"  = "application/json"
 }
 
 $stateGistBanner = @"

--- a/action.ps1
+++ b/action.ps1
@@ -34,6 +34,7 @@ $gistsApiUrl = "https://api.github.com/gists"
 $apiHeaders = @{
     Accept        = "application/vnd.github.v2+json"
     Authorization = "token $gist_token"
+    Content-Type  = "application/json"
 }
 
 $stateGistBanner = @"

--- a/action.yml
+++ b/action.yml
@@ -75,5 +75,5 @@ branding:
 ## Even though the Action logic may be implemented
 ## in PWSH, we still need a NodeJS entry point
 runs:
-  using: node12
+  using: node20
   main: _init/index.js

--- a/action.yml
+++ b/action.yml
@@ -75,5 +75,5 @@ branding:
 ## Even though the Action logic may be implemented
 ## in PWSH, we still need a NodeJS entry point
 runs:
-  using: node20
+  using: node24
   main: _init/index.js


### PR DESCRIPTION
As of a few days ago, this action started throwing the exception:
```
Invoke-WebRequest: /home/runner/work/_actions/zyborg/gh-action-buildnum/v1/action.ps1:158
Line |
 158 |  … eGistResp = Invoke-WebRequest -Headers $apiHeaders -Uri $updateGistUr …
     |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | The given key 'Content-Type' was not present in the dictionary.
```

This PR fixes that error.